### PR TITLE
Adding proxy supprt for ruby and git

### DIFF
--- a/dbuild/templates/dockerfile.jinja
+++ b/dbuild/templates/dockerfile.jinja
@@ -3,5 +3,9 @@ MAINTAINER {{ maintainer }}
 RUN echo 'http_proxy="{{ http_proxy }}"' >> /etc/environment
 RUN echo 'https_proxy="{{ https_proxy }}"' >> /etc/environment
 RUN echo 'Acquire::Http::Proxy "{{ http_proxy }}";' >> /etc/apt/apt.conf.d/90proxy
+RUN echo 'http_proxy: {{ http_proxy }}' > ~/.gemrc
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y dpkg-dev aptitude build-essential ; mkdir -p /usr/lib/pbuilder/
+RUN apt-get install -y git
+RUN git config --global http.proxy {{ http_proxy }}
+RUN git config --global https.proxy {{ http_proxy }}
 COPY scripts/pbuilder-satisfydepends* /usr/lib/pbuilder/


### PR DESCRIPTION
1. Puppet rjil build is failing while trying to install gem librarian puppet and doing git clone.
2. same is happening with ceph while cloning particulr repos during builds.
