### PR TITLE
Accept and ignore unknown kwargs

### DIFF
--- a/dbuild/__init__.py
+++ b/dbuild/__init__.py
@@ -117,6 +117,7 @@ def docker_build(build_dir, build_type, source_dir='source', force_rm=False,
     proxy:          value of proxy to be passed when used behind proxy settings
                     otherwise it will be default empty
     build_owner:    user id which will own all build files
+    kwargs:         dict of unknown arguments. Ignored. For forward compatibility.
     """
 
     command = ''

--- a/dbuild/__init__.py
+++ b/dbuild/__init__.py
@@ -96,7 +96,7 @@ def docker_build(build_dir, build_type, source_dir='source', force_rm=False,
                  docker_url='unix://var/run/docker.sock', dist='ubuntu',
                  release='trusty', extra_repos_file='repos',
                  extra_repo_keys_file='keys', build_cache=True, proxy="",
-                 build_owner=None):
+                 build_owner=None, **kwargs):
     """
     build_dir:  build directory, this directory will be mounted to /build in
                 container


### PR DESCRIPTION
This allows consumers to pass arguments in that are not yet supported,
thus decoupling python-dbuild and its consumers slightly.
